### PR TITLE
restore ability to have no groups ( with no tabs shown).

### DIFF
--- a/sigal.class.php
+++ b/sigal.class.php
@@ -143,7 +143,7 @@ class Sigal {
       $albs_by_group[$group][] = $a;
     }
     $tabs = 100; // counter for tabs IDs
-    if(count($albs_by_group) >= 1) {
+    if(count($albs_by_group) > 1 || ( count($albs_by_group) == 1 && strlen($albs_by_year[0]) > 0) ) {
       $groups = array_keys($albs_by_group);
       echo '<ul class="tabs">';
       foreach ($groups as $g) {


### PR DESCRIPTION
restore ability to have no groups ( with no tabs shown).

I think my previous change may have been misinterpreted.
-    if(count($albs_by_year) > 1 || count($albs_by_year) == 1 && strlen($albs_by_year[0]) > 0) {
-    if(count($albs_by_group) >= 1 && strlen($albs_by_group[0]) > 0) {

Note, these lines are not equivalent. The first is checking for a special case of a single element with an empty string. The replacement required that the first element was never empty. Perhaps ()'s would have made the order of operations clearer. I added ()'s in this pull request to make it clearer.

The purpose of the special case was to allow no grouping (no tabs) at allow with a function like:

  function get_groupname($bn) {
    return '';
  }

The above logic change combined with the 'Fix of broken grouping' change broke this functionality. 
-    if(count($albs_by_group) >= 1 && strlen($albs_by_group[0]) > 0) {
-    if(count($albs_by_group) >= 1) {
