### PR TITLE
allow sub-gallery.  recursive getalbums example

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -1,8 +1,8 @@
 <?php
   /** Directory with pictures. */
-  $conf['dir'] = './pictures/';
+  $conf['dir'] = 'pictures';
   /** Directory for caching thumbnails (must be writeable!).*/
-  $conf['cache'] = './cache/';
+  $conf['cache'] = 'cache';
   /** URL to default album and picture icon. May be absolute or relative. */
   $conf['defaultIcon'] = '?static=defico';
   /** Name of file with definition of title image. */

--- a/index.php
+++ b/index.php
@@ -56,7 +56,7 @@
   if (isset($_GET['salb'])) {
     session_start();
     if (isset($_POST['fakce']) && $_POST['fakce']==='addaccess') $gg->addAccess();
-    $gg->showAlbum(urlencode($gg->dir).$_GET['salb'].urlencode('/'));
+    $gg->showAlbum(urlencode($gg->dir).'/'.$_GET['salb']);
     die();
   }
   /*========================================================================*/


### PR DESCRIPTION
1. allow album (base) paths to be more than one level. remove trailing slash requirement (from internal code and custom functions, like func_getalbums)
2. (requires 1) allow sub-gallery.  If directory has no images/media, assume it is a sub-gallery
3. (requires 1) add recursive example for func_getalbums
