### PR TITLE
correct use of func_scandir ($array -> $dir).

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -63,7 +63,7 @@
   }
   /** Example implementation of getting pictures from directory. Usefull eg. when you want to skip some of them. */
   function myscandir($dir) {
-    $files = glob($dir.'*.tiff');
+    $files = glob($dir.'/*.tiff');
     return $files;
   }
   /** Example implementation of album sorting. */

--- a/demo/config.php
+++ b/demo/config.php
@@ -59,7 +59,7 @@
   }
   /** Example implementation of getting pictures from directory. Usefull eg. when you want to skip some of them. */
   function myscandir($dir) {
-    $files = glob($dir.'*.tiff');
+    $files = glob($dir.'/*.tiff');
     return $files;
   }
   /** Example implementation of album sorting. */

--- a/sigal.class.php
+++ b/sigal.class.php
@@ -527,7 +527,7 @@ class Sigal {
 
     // if we have scanning callback defined, lets use it...
     if (isset($this->func_scandir) && $this->func_scandir !== NULL && function_exists($this->func_scandir)) {
-      $files = call_user_func($this->func_scandir, $array);
+      $files = call_user_func($this->func_scandir, $dir);
     } else {
       $r = glob($dir.'/*');
       foreach($r as $file) {


### PR DESCRIPTION
correct use of func_scandir ($array -> $dir).  fix scandir example.  dir no longer has trailing slash.
